### PR TITLE
kg fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 Let's you count things by calling the increment action.
 
 # How to use
-* Go the config of the adapter and add new timers
-* Go to the things view and add the new timers
+* Go the config of the adapter and add new counters
+* Go to the things view and add the new counters
 
 # Actions
 * reset()

--- a/package.json
+++ b/package.json
@@ -37,22 +37,22 @@
       "properties": {
         "timers": {
           "type": "array",
-          "title": "A list of timers",
+          "title": "A list of counters",
           "items": {
             "type": "object",
-            "title": "A timer",
+            "title": "A counter",
             "required": [
               "name"
             ],
             "properties": {
               "id": {
                 "type": "string",
-                "title": "The id of the timer (will be generated for you)",
+                "title": "The id of the counter (will be generated for you)",
                 "readOnly": true
               },
               "name": {
                 "type": "string",
-                "title": "The name of the timer"
+                "title": "The name of the counter"
               }
             }
           }


### PR DESCRIPTION
Looks like the timer add-on was used as the starting point for the counter add-on, but not all uses of the word "timer" or "timers" in the user interface (and readme) had been changed to "counter(s)". 